### PR TITLE
feat: Add multi-account support and prioritize Edge for web links

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -256,6 +256,13 @@ def json_save(path: Path, contents: Mapping[Any, Any], *, sort: bool = False) ->
 
 def webopen(url: URL | str):
     url_str = str(url)
+    try:
+        browser = webbrowser.get('msedge')
+        browser.open_new_tab(url_str)
+        return
+    except webbrowser.Error:
+        pass  # fallback to default
+
     if IS_PACKAGED and sys.platform == "linux":
         # https://pyinstaller.org/en/stable/
         # runtime-information.html#ld-library-path-libpath-considerations


### PR DESCRIPTION
This commit introduces two new features:
1. Multi-account support via a `--profile` command-line argument. This allows running multiple instances of the application with isolated data.
2. The application will now prioritize using Microsoft Edge when opening web links for authentication. It falls back to the system's default browser if Edge is not found.